### PR TITLE
Added receive and send SQL functions to data types

### DIFF
--- a/inout.c
+++ b/inout.c
@@ -1,6 +1,8 @@
 #include <postgres.h>
 #include <fmgr.h>
 #include <utils/builtins.h>
+#include <lib/stringinfo.h>
+#include <libpq/pqformat.h>
 
 #include "uint.h"
 
@@ -26,6 +28,27 @@ int1out(PG_FUNCTION_ARGS)
 
 	sprintf(result, "%d", arg1);
 	PG_RETURN_CSTRING(result);
+}
+
+PG_FUNCTION_INFO_V1(int1recv);
+Datum
+int1recv(PG_FUNCTION_ARGS)
+{
+	StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+
+	PG_RETURN_INT8((int8) pq_getmsgint(buf, sizeof(int8)));
+}
+
+PG_FUNCTION_INFO_V1(int1send);
+Datum
+int1send(PG_FUNCTION_ARGS)
+{
+	int8 arg1 = PG_GETARG_INT8(0);
+	StringInfoData buf;
+
+	pq_begintypsend(&buf);
+	pq_sendint8(&buf, arg1);
+	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
 }
 
 static uint32
@@ -111,6 +134,27 @@ uint1out(PG_FUNCTION_ARGS)
 	PG_RETURN_CSTRING(result);
 }
 
+PG_FUNCTION_INFO_V1(uint1recv);
+Datum
+uint1recv(PG_FUNCTION_ARGS)
+{
+	StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+
+	PG_RETURN_UINT8((uint8) pq_getmsgint(buf, sizeof(uint8)));
+}
+
+PG_FUNCTION_INFO_V1(uint1send);
+Datum
+uint1send(PG_FUNCTION_ARGS)
+{
+	uint8 arg1 = PG_GETARG_UINT8(0);
+	StringInfoData buf;
+
+	pq_begintypsend(&buf);
+	pq_sendint8(&buf, arg1);
+	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
+}
+
 PG_FUNCTION_INFO_V1(uint2in);
 Datum
 uint2in(PG_FUNCTION_ARGS)
@@ -131,6 +175,27 @@ uint2out(PG_FUNCTION_ARGS)
 	PG_RETURN_CSTRING(result);
 }
 
+PG_FUNCTION_INFO_V1(uint2recv);
+Datum
+uint2recv(PG_FUNCTION_ARGS)
+{
+	StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+
+	PG_RETURN_UINT16((uint16) pq_getmsgint(buf, sizeof(uint16)));
+}
+
+PG_FUNCTION_INFO_V1(uint2send);
+Datum
+uint2send(PG_FUNCTION_ARGS)
+{
+	uint16 arg1 = PG_GETARG_UINT16(0);
+	StringInfoData buf;
+
+	pq_begintypsend(&buf);
+	pq_sendint16(&buf, arg1);
+	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
+}
+
 PG_FUNCTION_INFO_V1(uint4in);
 Datum
 uint4in(PG_FUNCTION_ARGS)
@@ -149,6 +214,27 @@ uint4out(PG_FUNCTION_ARGS)
 
 	sprintf(result, "%u", arg1);
 	PG_RETURN_CSTRING(result);
+}
+
+PG_FUNCTION_INFO_V1(uint4recv);
+Datum
+uint4recv(PG_FUNCTION_ARGS)
+{
+	StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+
+	PG_RETURN_UINT32((uint32) pq_getmsgint(buf, sizeof(uint32)));
+}
+
+PG_FUNCTION_INFO_V1(uint4send);
+Datum
+uint4send(PG_FUNCTION_ARGS)
+{
+	uint32 arg1 = PG_GETARG_UINT32(0);
+	StringInfoData buf;
+
+	pq_begintypsend(&buf);
+	pq_sendint32(&buf, arg1);
+	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
 }
 
 PG_FUNCTION_INFO_V1(uint8in);
@@ -203,3 +289,25 @@ uint8out(PG_FUNCTION_ARGS)
 	sprintf(result, "%"PRIu64, (uint64_t) arg1);
 	PG_RETURN_CSTRING(result);
 }
+
+PG_FUNCTION_INFO_V1(uint8recv);
+Datum
+uint8recv(PG_FUNCTION_ARGS)
+{
+	StringInfo buf = (StringInfo) PG_GETARG_POINTER(0);
+
+	PG_RETURN_UINT64((uint64) pq_getmsgint(buf, sizeof(uint64)));
+}
+
+PG_FUNCTION_INFO_V1(uint8send);
+Datum
+uint8send(PG_FUNCTION_ARGS)
+{
+	uint64 arg1 = PG_GETARG_UINT64(0);
+	StringInfoData buf;
+
+	pq_begintypsend(&buf);
+	pq_sendint64(&buf, arg1);
+	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
+}
+

--- a/uint.sql
+++ b/uint.sql
@@ -12,9 +12,23 @@ CREATE FUNCTION int1out(int1) RETURNS cstring
     LANGUAGE C
     AS '$libdir/uint', 'int1out';
 
+CREATE FUNCTION int1recv(internal) RETURNS int1
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'int1recv';
+
+CREATE FUNCTION int1send(int1) RETURNS bytea
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'int1send';
+
 CREATE TYPE int1 (
     INPUT = int1in,
     OUTPUT = int1out,
+    RECEIVE = int1recv,
+    SEND = int1send,
     INTERNALLENGTH = 1,
     PASSEDBYVALUE,
     ALIGNMENT = char
@@ -43,9 +57,23 @@ CREATE FUNCTION uint1out(uint1) RETURNS cstring
     LANGUAGE C
     AS '$libdir/uint', 'uint1out';
 
+CREATE FUNCTION uint1recv(internal) RETURNS uint1
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint1recv';
+
+CREATE FUNCTION uint1send(uint1) RETURNS bytea
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint1send';
+
 CREATE TYPE uint1 (
     INPUT = uint1in,
     OUTPUT = uint1out,
+    RECEIVE = uint1recv,
+    SEND = uint1send,
     INTERNALLENGTH = 1,
     PASSEDBYVALUE,
     ALIGNMENT = char
@@ -74,9 +102,23 @@ CREATE FUNCTION uint2out(uint2) RETURNS cstring
     LANGUAGE C
     AS '$libdir/uint', 'uint2out';
 
+CREATE FUNCTION uint2recv(internal) RETURNS uint2
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint2recv';
+
+CREATE FUNCTION uint2send(uint2) RETURNS bytea
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint2send';
+
 CREATE TYPE uint2 (
     INPUT = uint2in,
     OUTPUT = uint2out,
+    RECEIVE = uint2recv,
+    SEND = uint2send,
     INTERNALLENGTH = 2,
     PASSEDBYVALUE,
     ALIGNMENT = int2
@@ -105,9 +147,23 @@ CREATE FUNCTION uint4out(uint4) RETURNS cstring
     LANGUAGE C
     AS '$libdir/uint', 'uint4out';
 
+CREATE FUNCTION uint4recv(internal) RETURNS uint4
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint4recv';
+
+CREATE FUNCTION uint4send(uint4) RETURNS bytea
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint4send';
+
 CREATE TYPE uint4 (
     INPUT = uint4in,
     OUTPUT = uint4out,
+    RECEIVE = uint4recv,
+    SEND = uint4send,
     INTERNALLENGTH = 4,
     PASSEDBYVALUE,
     ALIGNMENT = int4
@@ -136,9 +192,23 @@ CREATE FUNCTION uint8out(uint8) RETURNS cstring
     LANGUAGE C
     AS '$libdir/uint', 'uint8out';
 
+CREATE FUNCTION uint8recv(internal) RETURNS uint8
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint8recv';
+
+CREATE FUNCTION uint8send(uint8) RETURNS bytea
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint', 'uint8send';
+
 CREATE TYPE uint8 (
     INPUT = uint8in,
     OUTPUT = uint8out,
+    RECEIVE = uint8recv,
+    SEND = uint8send,
     INTERNALLENGTH = 8,
     @UINT8_PASSEDBYVALUE@
     ALIGNMENT = double


### PR DESCRIPTION
Added receive and send SQL functions to data types (int8, uint8, uint16, uint32 and uint64).

Without it, getting "no binary output function available for type <data type>" error in a code that uses postgres C API on the client side.